### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A Model Context Protocol (MCP) server implementation that connects Large Language Models (LLMs) to the GeoServer REST API, enabling AI assistants to interact with geospatial data and services.
 
+<a href="https://glama.ai/mcp/servers/@mahdin75/geoserver-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mahdin75/geoserver-mcp/badge" alt="GeoServer Server MCP server" />
+</a>
+
 ## 🚀 Features
 
 - 🔍 Query and manipulate GeoServer workspaces, layers, and styles


### PR DESCRIPTION
This PR adds a badge for the [GeoServer MCP Server](https://glama.ai/mcp/servers/@mahdin75/geoserver-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@mahdin75/geoserver-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mahdin75/geoserver-mcp/badge" alt="GeoServer Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.