### PR TITLE
Change return type of list_workspaces to Dict[str, List[str]]

### DIFF
--- a/src/geoserver_mcp/main.py
+++ b/src/geoserver_mcp/main.py
@@ -116,7 +116,7 @@ def get_wfs_resource(request: str) -> Dict[str, Any]:
 # Tool implementations
 
 @mcp.tool()
-def list_workspaces() -> List[str]:
+def list_workspaces() -> Dict[str, List[str]]:
     """List available workspaces in GeoServer."""
     geo = get_geoserver()
     if geo is None:

--- a/src/geoserver_mcp/main.py
+++ b/src/geoserver_mcp/main.py
@@ -1270,4 +1270,4 @@ def main():
         sys.exit(1)
 
 if __name__ == "__main__":
-    main() 
+    main()


### PR DESCRIPTION
While testing this mcp server, we ran into an issue that the workspaces couldn't be listed. Layer queries, wfs and wms seemed to work.

Logging showed it was an pydantic typing error. The two functions had diffent return types. I changed the return type of `list_workspaces `according to `get_workspaces`.

```
"Error executing tool list_workspaces: 1 validation error for list_workspacesOutput\nresult.workspaces\n  Input should be a valid list [type=list_type, input_value={'workspace':[{'n...ba1_wind_fixed.json'}]}}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.12/v/list_type"}
```

